### PR TITLE
Bump DM Frontend to 4.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "digitalmarketplace-frontend": "4.3.0"
+        "digitalmarketplace-frontend": "4.3.3"
       }
     },
     "node_modules/accessible-autocomplete": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/digitalmarketplace-frontend": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-frontend/-/digitalmarketplace-frontend-4.3.0.tgz",
-      "integrity": "sha512-/GGMMlDBZKMqCd4pw4uDlkw810x0ojpeyBU/c40DCjqtpuwFxzIpcFsx1iH0TiHzQKxB4v4YqqCpGqYxYd5sYg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-frontend/-/digitalmarketplace-frontend-4.3.3.tgz",
+      "integrity": "sha512-KUdIdXVvVsDFDK7237qTyG9zs9X3Jz0yhO6pXdYhJjGgYLaQLGT6+d9lpYiuywajZYOyRR6T+QB2fifwVN55Kw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "author": "CCS",
   "license": "MIT",
   "devDependencies": {
-    "digitalmarketplace-frontend": "4.3.0"
+    "digitalmarketplace-frontend": "4.3.3"
   }
 }


### PR DESCRIPTION
4.3.3 drops the indeterminate mark from the option-tree's independent selection mode. The change is JavaScript-only, so the macro and its fixtures are untouched and the parity suite passes unchanged; no new package release is needed.